### PR TITLE
Allow for specifying output directory

### DIFF
--- a/furniture_converter.py
+++ b/furniture_converter.py
@@ -170,10 +170,10 @@ def main(CFfilename, originalLocation, tilesheetLocation):
 		if shouldSell:
 			dga_shop_entries.append({
 				"$ItemType": "ShopEntry",
-			    "Item": { "Value": modAuthor + ".DGA." + modName + "/" + itemID },
-			    "ShopId": shopName,
-			    "MaxSold": 1,
-			    "Cost": itemPrice,
+					"Item": { "Value": modAuthor + ".DGA." + modName + "/" + itemID },
+					"ShopId": shopName,
+					"MaxSold": 1,
+					"Cost": itemPrice,
 			},)
 
 		#### CP
@@ -266,14 +266,14 @@ def main(CFfilename, originalLocation, tilesheetLocation):
 
 	# Add the extra stuff to the CP json
 	actual_cp_data = {
-	    "Format": "1.26.0",
-	    "Changes": [
-	        {
-	            "Action": "EditData",
-	            "Target": "Data/Furniture",
-	            "Entries": cp_data
-	        },
-	    ]
+			"Format": "1.26.0",
+			"Changes": [
+					{
+							"Action": "EditData",
+							"Target": "Data/Furniture",
+							"Entries": cp_data
+					},
+			]
 	}
 
 	# Add in loading the textures
@@ -287,17 +287,17 @@ def main(CFfilename, originalLocation, tilesheetLocation):
 	# Create the content.json for DGA
 	dga_content_data = [
 		{
-	        "$ItemType": "ContentIndex",
-	        "FilePath": "furniture.json"
-	    },
+					"$ItemType": "ContentIndex",
+					"FilePath": "furniture.json"
+			},
 	]
 
 	# Add shop entries json to DGA content if needed
 	if shouldSell:
 		dga_content_data.append({
-	        "$ItemType": "ContentIndex",
-	        "FilePath": "shopEntries.json"
-	    },)
+					"$ItemType": "ContentIndex",
+					"FilePath": "shopEntries.json"
+			},)
 
 	# Make a new manifest for DGA
 	dga_manifest = {
@@ -312,7 +312,7 @@ def main(CFfilename, originalLocation, tilesheetLocation):
 			"MinimumVersion": "1.4.2",
 		},
 		"DGA.FormatVersion": 2,
-	    "DGA.ConditionsFormatVersion": "1.25.0"
+			"DGA.ConditionsFormatVersion": "1.25.0"
 	}
 
 	# Make a new manifest for CP
@@ -376,15 +376,15 @@ def load_json(filepath, filename):
 	file_contents = file_contents.replace(u'\u201c', '"').replace(u'\u201d', '"')
 
 	try:
-	    # Try using the standard module first because it's fast and handles most cases.
+			# Try using the standard module first because it's fast and handles most cases.
 		data = json.loads(file_contents)
 	except json.decoder.JSONDecodeError:
-	    # The json5 module is much slower, but is more lenient about formatting issues.
-	    try:
-	    	data = json5.loads(file_contents)
-	    except json.decoder.JSONDecodeError:
-	    	data = {}
-	    	print("The json file (" + filename + ") specified is not a valid json file. Please try putting it through smapi.io/json and correcting any errors shown there.")
+			# The json5 module is much slower, but is more lenient about formatting issues.
+			try:
+				data = json5.loads(file_contents)
+			except json.decoder.JSONDecodeError:
+				data = {}
+				print("The json file (" + filename + ") specified is not a valid json file. Please try putting it through smapi.io/json and correcting any errors shown there.")
 
 	# Return the data loaded
 	return data

--- a/furniture_converter.py
+++ b/furniture_converter.py
@@ -22,6 +22,7 @@ def main(CFfilename, originalLocation, tilesheetLocation):
 	parser.add_argument('--modName', type=str, required=True, help="Name of the mod (no spaces), should be identifying")
 	parser.add_argument('--modAuthor', type=str, required=False, help="Author of the original mod (no spaces)")
 	parser.add_argument('--sellAt', type=str, required=False, help="Name of shop to sell furniture at. Options are found at https://github.com/spacechase0/StardewValleyMods/blob/develop/DynamicGameAssets/docs/author-guide.md#valid-shop-ids-for-vanilla")
+	parser.add_argument('--outputDirectory', type=str, required=False, help="Optional specific output directory. Will add -1.6 to end for 1.6 version")
 	# Parse the argument
 	args = parser.parse_args()
 
@@ -329,7 +330,7 @@ def main(CFfilename, originalLocation, tilesheetLocation):
 	}
 
 	## Save all the DGA json files in an appropriately named folder
-	dga_folder_path = Path("[DGA] " + manifest["Name"])
+	dga_folder_path = args.outputDirectory if args.outputDirectory else Path("[DGA] " + manifest["Name"])
 	dga_i18n_path = dga_folder_path.joinpath("i18n")
 	save_json(dga_data, dga_folder_path, "furniture.json")
 	save_json(dga_content_data, dga_folder_path, "content.json")
@@ -339,7 +340,7 @@ def main(CFfilename, originalLocation, tilesheetLocation):
 		save_json(dga_shop_entries, dga_folder_path, "shopEntries.json")
 
 	## Save all of the CP json files in an appropriately named folder
-	cp_folder_path = Path("[CP] FOR ALPHA ONLY " + manifest["Name"])
+	cp_folder_path = args.outputDirectory + '-1.6' if args.outputDirectory else Path("[CP] FOR ALPHA ONLY " + manifest["Name"])
 	cp_i18n_path = cp_folder_path.joinpath("i18n")
 	save_json(actual_cp_data, cp_folder_path,"content.json")
 	save_json(cp_manifest,cp_folder_path,"manifest.json")


### PR DESCRIPTION
This PR adds an optional `--outputDirectory`, which you can use to specify the output directory specifically. It will add `-1.6` to the end of the folder name for the 1.6 versions of the mods.

It also removes the inconsistent space usage, and sticks to tabs as they're the overwhelming major of the file's indentation.